### PR TITLE
Change: Improve language strings

### DIFF
--- a/lang/english.lng
+++ b/lang/english.lng
@@ -1,8 +1,10 @@
 ##grflangid 0x01
+##plural 0
+# 0 indicates the plural system used
 # This is the English language file
 
 # GRF name and description definitions
-STR_TWTS_NAME        :{TITLE} {VERSION}
+STR_TWTS_NAME        :{TITLE} {PUSH_COLOUR}{WHITE}{VERSION}{POP_COLOUR}
 STR_TWTS_DESCRIPTION :Taiwan Trains Set{}{COPYRIGHT}2024 TeamTWTS{}License: GPL v3
 
 # vehicle names
@@ -72,29 +74,17 @@ STR_PARAM_LENGTH_10         : 10/8
 STR_EMU500_DESC : EMU500 Commuter Electric Muitiple Unit Train
 TRMUCAR_DESC : {BLUE}Used to represent  {GREEN}motor and trailer cars{BLUE} within an EMU formation. {}{RED}Cannot be the rear of an EMU consist.
 
-STR_TRLENGTH_1T :{BLACK}Valid formation: {STRING} - car formations{}
-STR_TRLENGTH_2T	:{BLACK}Valid formation: {STRING} / {STRING} - car formations{}
-STR_TRLENGTH_3T	:{BLACK}Valid formation: {STRING} / {STRING} / {STRING} - car formations{}
-STR_TRLENGTH_4T	:{BLACK}Valid formation: {STRING} / {STRING} / {STRING} / {STRING} - car formations{}
-STR_TRLENGTH_5T	:{BLACK}Valid formation: {STRING} / {STRING} / {STRING} / {STRING} / {STRING} - car formations{}
-STR_TRLENGTH_6T	:{BLACK}Valid formation: {STRING} / {STRING} / {STRING} / {STRING} / {STRING} / {STRING} - car formations{}
+# The {P "" s} here is only for the English language file; P stands for plural
+# It varys in other languages. Say, there is no need for them in the Chinese / Japanese langauge files.
+# Basically, when the value of {COMMA} not 0, it will be replaced by "s", otherwise, it will be replaced by "".
 
-STR_TRLENGTH_1C:{GOLD}1{BLACK}
-STR_TRLENGTH_2C:{GOLD}2{BLACK}
-STR_TRLENGTH_3C:{GOLD}3{BLACK}
-STR_TRLENGTH_4C:{GOLD}4{BLACK}
-STR_TRLENGTH_5C:{GOLD}5{BLACK}
-STR_TRLENGTH_6C:{GOLD}6{BLACK}
-STR_TRLENGTH_7C:{GOLD}7{BLACK}
-STR_TRLENGTH_8C:{GOLD}8{BLACK}
-STR_TRLENGTH_9C:{GOLD}9{BLACK}
-STR_TRLENGTH_10C:{GOLD}10{BLACK}
-STR_TRLENGTH_11C:{GOLD}11{BLACK}
-STR_TRLENGTH_12C:{GOLD}12{BLACK}
-STR_TRLENGTH_13C:{GOLD}13{BLACK}
-STR_TRLENGTH_14C:{GOLD}14{BLACK}
-STR_TRLENGTH_15C:{GOLD}15{BLACK}
-STR_TRLENGTH_16C:{GOLD}16{BLACK}
+STR_TRLENGTH_1T    :{BLACK}Valid formation: {PUSH_COLOUR}{GOLD}{COMMA} car{P "" s}{}{POP_COLOUR}
+STR_TRLENGTH_2T    :{BLACK}Valid formations: {PUSH_COLOUR}{GOLD}{COMMA}/{COMMA} car{P "" s}{}{POP_COLOUR}
+STR_TRLENGTH_3T    :{BLACK}Valid formations: {PUSH_COLOUR}{GOLD}{COMMA}/{COMMA}/{COMMA} car{P "" s}{}{POP_COLOUR}
+STR_TRLENGTH_4T    :{BLACK}Valid formations: {PUSH_COLOUR}{GOLD}{COMMA}/{COMMA}/{COMMA}/{COMMA} car{P "" s}{}{POP_COLOUR}
+STR_TRLENGTH_5T    :{BLACK}Valid formations: {PUSH_COLOUR}{GOLD}{COMMA}/{COMMA}/{COMMA}/{COMMA}/{COMMA} car{P "" s}{}{POP_COLOUR}
+STR_TRLENGTH_6T    :{BLACK}Valid formations: {PUSH_COLOUR}{GOLD}{COMMA}/{COMMA}/{COMMA}/{COMMA}/{COMMA}/{COMMA} car{P "" s}{}{POP_COLOUR}
+STR_TRLENGTH_RANGE :{BLACK}Valid formation: {PUSH_COLOUR}{GOLD}{COMMA}-{COMMA} car{P "" s}{}{POP_COLOUR}
 
 # ################
 # CONCAT SUBSTRINGS#
@@ -109,7 +99,7 @@ STR_CONCAT_3S	:{STRING}{STRING}{STRING}
 STR_CONCAT_4S	:{STRING}{STRING}{STRING}{STRING}
 STR_CONCAT_5S	:{STRING}{STRING}{STRING}{STRING}{STRING}
 
-STR_CONCAT_1C	:{BLACK}Operators: {STRING}{}
+STR_CONCAT_1C	:{BLACK}Operator: {STRING}{}
 STR_CONCAT_2C	:{BLACK}Operators: {STRING} / {STRING}{}
 STR_CONCAT_3C	:{BLACK}Operators: {STRING} / {STRING} / {STRING}{}
 STR_CONCAT_4C	:{BLACK}Operators: {STRING} / {STRING} / {STRING} / {STRING}{}

--- a/src/emu/emu200.pnml
+++ b/src/emu/emu200.pnml
@@ -92,26 +92,20 @@ item(FEAT_TRAINS, emu200) {
     }
     /*Graphics and Callbacks*/
       graphics { // graphics for engine
-         additional_text:  string(STR_CONCAT_5S, 
+         additional_text:  string(STR_CONCAT_5S,
                         string(STR_DESC_POWER_AC20),
                         string(STR_DESC_NARROWGAUGE),
                         string(STR_DESC_USAGE_PAX_EXP),
-                        string(STR_TRLENGTH_5T,
-                           string(STR_TRLENGTH_3C),
-                           string(STR_TRLENGTH_6C),
-                           string(STR_TRLENGTH_9C),
-                           string(STR_TRLENGTH_12C),
-                           string(STR_TRLENGTH_15C)
-                         ),
-                        string(STR_CONCAT_1C, 
+                        string(STR_TRLENGTH_5T, 3, 6, 9, 12, 15),
+                        string(STR_CONCAT_1C,
                            string(STR_SUFFIX_TRA),
                         )
                   );
         cargo_capacity: return 48;
-        default:                switch_emu200_gfx_pos;
-            purchase:               spriteset_emu200_purchase;
-        can_attach_wagon:             switch_emu200_attach_vehid;
-        start_stop:           switch_emu200_start_stop;
+        default:                 switch_emu200_gfx_pos;
+        purchase:                spriteset_emu200_purchase;
+        can_attach_wagon:        switch_emu200_attach_vehid;
+        start_stop:              switch_emu200_start_stop;
     }
     /*Multiple Unit Car*/
       livery_override(trmu_car){

--- a/src/emu/emu300.pnml
+++ b/src/emu/emu300.pnml
@@ -179,18 +179,12 @@ item(FEAT_TRAINS, emu300) {
     }
     /*Graphics and Callbacks*/
       graphics { // graphics for engine
-         additional_text:  string(STR_CONCAT_5S, 
+         additional_text:  string(STR_CONCAT_5S,
                         string(STR_DESC_POWER_AC20),
                         string(STR_DESC_NARROWGAUGE),
                         string(STR_DESC_USAGE_PAX_EXP),
-                        string(STR_TRLENGTH_5T,
-                           string(STR_TRLENGTH_3C),
-                           string(STR_TRLENGTH_6C),
-                           string(STR_TRLENGTH_9C),
-                           string(STR_TRLENGTH_12C),
-                           string(STR_TRLENGTH_15C)
-                         ),
-                        string(STR_CONCAT_1C, 
+                        string(STR_TRLENGTH_5T, 3, 6, 9, 12, 15),
+                        string(STR_CONCAT_1C,
                            string(STR_SUFFIX_TRA),
                         )
                   );

--- a/src/emu/emu400.pnml
+++ b/src/emu/emu400.pnml
@@ -104,12 +104,7 @@ item(FEAT_TRAINS, emu400) {
                         string(STR_DESC_POWER_AC20),
                         string(STR_DESC_NARROWGAUGE),
                         string(STR_DESC_USAGE_PAX_LOC),
-                        string(STR_TRLENGTH_4T,
-                           string(STR_TRLENGTH_4C),
-                           string(STR_TRLENGTH_8C),
-                           string(STR_TRLENGTH_12C),
-                           string(STR_TRLENGTH_16C)
-                         ),
+                        string(STR_TRLENGTH_4T, 4, 8, 12, 16),
                         string(STR_CONCAT_1C, 
                            string(STR_SUFFIX_TRA),
                         )

--- a/src/emu/emu500.pnml
+++ b/src/emu/emu500.pnml
@@ -104,12 +104,7 @@ item(FEAT_TRAINS, emu500) {
                         string(STR_DESC_POWER_AC20),
                         string(STR_DESC_NARROWGAUGE),
                         string(STR_DESC_USAGE_PAX_LOC),
-                        string(STR_TRLENGTH_4T,
-                           string(STR_TRLENGTH_4C),
-                           string(STR_TRLENGTH_8C),
-                           string(STR_TRLENGTH_12C),
-                           string(STR_TRLENGTH_16C)
-                         ),
+                        string(STR_TRLENGTH_4T, 4, 8, 12, 16),
                         string(STR_CONCAT_1C, 
                            string(STR_SUFFIX_TRA),
                         )

--- a/src/emu/emu600.pnml
+++ b/src/emu/emu600.pnml
@@ -104,12 +104,7 @@ item(FEAT_TRAINS, emu600) {
                         string(STR_DESC_POWER_AC20),
                         string(STR_DESC_NARROWGAUGE),
                         string(STR_DESC_USAGE_PAX_LOC),
-                        string(STR_TRLENGTH_4T,
-                           string(STR_TRLENGTH_4C),
-                           string(STR_TRLENGTH_8C),
-                           string(STR_TRLENGTH_12C),
-                           string(STR_TRLENGTH_16C)
-                         ),
+                        string(STR_TRLENGTH_4T, 4, 8, 12, 16),
                         string(STR_CONCAT_1C, 
                            string(STR_SUFFIX_TRA),
                         )

--- a/src/emu/emu800.pnml
+++ b/src/emu/emu800.pnml
@@ -213,9 +213,7 @@ item(FEAT_TRAINS, emu800) {
                         string(STR_DESC_POWER_AC20),
                         string(STR_DESC_NARROWGAUGE),
                         string(STR_DESC_USAGE_PAX_LOC),
-                        string(STR_TRLENGTH_1T,
-                           string(STR_TRLENGTH_8C)
-                         ),
+                        string(STR_TRLENGTH_1T, 8),
                         string(STR_CONCAT_1C, 
                            string(STR_SUFFIX_TRA),
                         )


### PR DESCRIPTION
See https://github.com/OpenTTD-China-Set/China-Set-Buses/pull/1

Basically, `{COMMA}` recieves an integer, and further encodes it to a string.

The compiler would require a compile-time constant for `{COMMA}`.